### PR TITLE
hshome: BOJ_14502.py 연구소 풀이

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ssafy-algo-study.iml" filepath="$PROJECT_DIR$/.idea/ssafy-algo-study.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/ssafy-algo-study.iml
+++ b/.idea/ssafy-algo-study.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/week04/yhs/BOJ_14502.py
+++ b/week04/yhs/BOJ_14502.py
@@ -4,7 +4,7 @@ from collections import deque
 
 def wall(lab, *args):
     # 벽 세우기
-    walled_lab = deepcopy(lab)  # 원본 행렬 바뀌는 것 방지
+    walled_lab = deepcopy(lab)  # 원본 행렬 바뀌는 것 방지하기 위해 copy 모듈 사용
 
     # *args(3개)의 좌표에 벽 세우기
     for coor in args:
@@ -14,7 +14,7 @@ def wall(lab, *args):
 
 
 def bfs(lab, virus):
-    infected = deepcopy(lab)    # 원본 행렬 바뀌는 것 방지
+    infected = deepcopy(lab)
     # delta
     drow = [1, 0, -1, 0]
     dcol = [0, 1, 0, -1]
@@ -28,9 +28,9 @@ def bfs(lab, virus):
             row = s[0]+drow[i]
             col = s[1]+dcol[i]
             # 인덱스 범위 내에 있고 빈 칸일 경우 바이러스 감염
-            if 0 <= row < n and 0 <= col < m and infected[row][col] == 0:
+            if 0 <= row < n and 0 <= col < m and not infected[row][col]:
                 queue.append([row, col])    # 큐에 추가
-                infected[row][col] = 2
+                infected[row][col] = 2      # 방문처리
 
     # 안전 영역 개수 세기
     count = 0
@@ -42,6 +42,42 @@ def bfs(lab, virus):
     return count
 
 
+def backtracking(depth, max_area):
+    # 깊이가 3까지 도달하면 bfs 함수 호출하여 안전 영역 구하기
+    if depth == 3:
+        walled = wall(lab, *arr)
+        area = bfs(walled, virus)
+
+        return area
+
+    # 가장 최근에 방문한 노드의 인덱스 구하기
+    if True in visited:
+        idx = length - visited[::-1].index(True)
+    else:
+        idx = 0
+
+    # 가장 최근에 방문한 노드의 다음 인덱스부터:
+    for i in range(idx, length):
+        # 방문하지 않았을 경우
+        if not visited[i]:
+            visited[i] = True   # 방문 처리 후
+            arr[depth] = empty[i]   # 벽을 세울 위치 리스트에 추가
+            temp = backtracking(depth + 1, max_area)    # backtracking 재귀호출, return 값(bfs 결과) temp에 저장
+            visited[i] = False  # 방문한 노드 초기화
+            # 안전 영역의 최대값 갱신하기
+            if temp > max_area:
+                max_area = temp
+
+    return max_area
+
+'''
+1. 벽을 세울 수 있는 위치(빈 칸)을 리스트에 모두 담는다
+2. 백트래킹으로 리스트 내 원소가 3개인 부분집합 모두 구한다
+3. 모든 부분집합에 대하여 bfs 실시
+4. bfs 실행한 결과 안전 영역의 최대 개수 구하기
+'''
+
+
 n, m = map(int, input().split())
 lab = [list(map(int, input().split())) for _ in range(n)]
 
@@ -49,6 +85,7 @@ empty = []  # 여기에 빈 칸의 좌표들이 들어감
 virus = []  # 여기에 바이러스의 좌표들이 들어감
 length = 0  # 벽 세우기 전의 빈 칸 개수
 
+# 행렬 조회하며 빈 칸과 바이러스 위치 확인
 for i in range(n):
     for j in range(m):
         filled = lab[i][j]
@@ -58,16 +95,7 @@ for i in range(n):
         if filled == 2:
             virus.append([i, j])    # 바이러스 좌표 추가
 
-# 안전 영역의 최대 개수 구하기
-max_area = 0
-# for문 3개 --> 빈 칸에 3개의 벽을 세우는 모든 경우
-for i in range(length - 2):
-    for j in range(i + 1, length - 1):
-        for k in range(j + 1, length):
-            walled_lab = wall(lab, empty[i], empty[j], empty[k])    # 벽 세운 후의 행렬
-            temp = bfs(walled_lab, virus)   # 바이러스가 퍼진 수 안전 영역의 개수
-            # 안전영역 최대값 갱신하기
-            if temp > max_area:
-                max_area = temp
-
-print(max_area)
+visited = [False for _ in range(length)]    # 방문여부 체크하는 리스트
+arr = [0, 0, 0]                             # 길이 3짜리 리스트에 세울 벽의 위치 담기
+result = backtracking(0, 0)
+print(result)

--- a/week04/yhs/BOJ_14502.py
+++ b/week04/yhs/BOJ_14502.py
@@ -1,0 +1,73 @@
+from copy import deepcopy
+from collections import deque
+
+
+def wall(lab, *args):
+    # 벽 세우기
+    walled_lab = deepcopy(lab)  # 원본 행렬 바뀌는 것 방지
+
+    # *args(3개)의 좌표에 벽 세우기
+    for coor in args:
+        walled_lab[coor[0]][coor[1]] = 1
+
+    return walled_lab
+
+
+def bfs(lab, virus):
+    infected = deepcopy(lab)    # 원본 행렬 바뀌는 것 방지
+    # delta
+    drow = [1, 0, -1, 0]
+    dcol = [0, 1, 0, -1]
+
+    queue = deque(virus)    # 큐에 바이러스 위치 넣기
+    # bfs 시작
+    while queue:
+        s = queue.popleft()
+        # 인접행렬 탐색하기
+        for i in range(4):
+            row = s[0]+drow[i]
+            col = s[1]+dcol[i]
+            # 인덱스 범위 내에 있고 빈 칸일 경우 바이러스 감염
+            if 0 <= row < n and 0 <= col < m and infected[row][col] == 0:
+                queue.append([row, col])    # 큐에 추가
+                infected[row][col] = 2
+
+    # 안전 영역 개수 세기
+    count = 0
+    for r in infected:
+        for c in r:
+            if c == 0:
+                count += 1
+
+    return count
+
+
+n, m = map(int, input().split())
+lab = [list(map(int, input().split())) for _ in range(n)]
+
+empty = []  # 여기에 빈 칸의 좌표들이 들어감
+virus = []  # 여기에 바이러스의 좌표들이 들어감
+length = 0  # 벽 세우기 전의 빈 칸 개수
+
+for i in range(n):
+    for j in range(m):
+        filled = lab[i][j]
+        if not filled:
+            empty.append([i, j])    # 빈 칸 좌표 추가
+            length += 1             # 빈 칸 개수 하나 추가
+        if filled == 2:
+            virus.append([i, j])    # 바이러스 좌표 추가
+
+# 안전 영역의 최대 개수 구하기
+max_area = 0
+# for문 3개 --> 빈 칸에 3개의 벽을 세우는 모든 경우
+for i in range(length - 2):
+    for j in range(i + 1, length - 1):
+        for k in range(j + 1, length):
+            walled_lab = wall(lab, empty[i], empty[j], empty[k])    # 벽 세운 후의 행렬
+            temp = bfs(walled_lab, virus)   # 바이러스가 퍼진 수 안전 영역의 개수
+            # 안전영역 최대값 갱신하기
+            if temp > max_area:
+                max_area = temp
+
+print(max_area)

--- a/week04/yhs/backtracking.py
+++ b/week04/yhs/backtracking.py
@@ -1,0 +1,66 @@
+
+
+import time
+
+
+
+# 작업 코드
+
+
+
+
+
+def backtracking(depth):
+    if depth == 3:
+        print(arr)
+        global num
+        num += 1
+        # print(arr)
+        return
+
+    if True in visited:
+        idx = length - visited[::-1].index(True)
+    else:
+        idx = 0
+
+    for i in range(idx, length):
+        if not visited[i]:
+            visited[i] = True
+            arr[depth] = empty[i]
+            backtracking(depth + 1)
+            visited[i] = False
+    # print(result)
+
+
+n, m = map(int, input().split())
+lab = [list(map(int, input().split())) for _ in range(n)]
+
+start = time.time()  # 시작 시간 저장
+
+empty = []  # 여기에 빈 칸의 좌표들이 들어감
+virus = []  # 여기에 바이러스의 좌표들이 들어감
+length = 0  # 벽 세우기 전의 빈 칸 개수
+
+for i in range(n):
+    for j in range(m):
+        filled = lab[i][j]
+        if not filled:
+            empty.append([i, j])    # 빈 칸 좌표 추가
+            length += 1             # 빈 칸 개수 하나 추가
+        if filled == 2:
+            virus.append([i, j])    # 바이러스 좌표 추가
+
+visited = [False for _ in range(length)]
+result = []
+arr = [0, 0, 0]
+num = 0
+wall_list = backtracking(0)
+
+# for i in range(length - 2):
+#     for j in range(i + 1, length - 1):
+#         for k in range(j + 1, length):
+#             print([empty[i], empty[j], empty[k]])
+
+
+
+print("time :", time.time() - start, num)  # 현재시각 - 시작시간 = 실행 시간


### PR DESCRIPTION
# 백준 14502번: 연구소

## 문제
N x M 행렬에 연구소의 지도가 주어진다. 0, 1, 2는 각각 빈 칸, 벽, 바이러스를 의미하고 바이러스는 상하좌우 인접한 빈 칸으로 계속 퍼질 수 있다. 바이러스가 모두 퍼졌을 때 빈 칸의 개수를 안전 영역이라고 할 때, 빈칸에 3개의 벽을 세워 얻을 수 있는 안전 영역 크기의 최댓값을 구하라.

### 풀이
1. 우선 빈 칸에 벽을 3개 세울 수 있는 모든 케이스를 구해야 한다. 이는 모든 빈 칸의 집합에서 원소가 3개인 부분 집합을 구하는 것과 같다. 이를 백트래킹(인지 아닌지는 잘 모르겠어요 ㅠ)으로 구현하였다.
2. 각 부분 집합에 대해 바이러스가 전부 퍼진 후의 안전 영역 크기를 계산하였다. 처음 바이러스의 모든 위치에서 BFS를 수행하여 바이러스가 퍼질 수 있는 영역이 모두 감염된 행렬을 생성하였다.
3. 위 행렬의 모든 항목을 조회하여 빈 칸(안전 영역)의 개수를 세고, 최댓값을 갱신하였다. 
 
#### `wall(lab, *args)`
연구소 지도 행렬(lab)과 벽을 세울 위치(*args: 벽을 세울 위치를 담은 3개의 리스트)를 인자로 받아 벽을 세운 후의 지도를 반환한다.

#### `bfs(lab, virus)`
매개변수 lab은 연구소 지도, virus는 바이러스 위치를 담은 리스트이다. 바이러스가 있는 곳에서 BFS를 수행하여 바이러스가 전부 퍼진 상태의 연구소 지도 행렬을 생성한다. 이후 안전 영역의 개수를 반환한다.

#### `backtracking(depth, max_area)`
3개의 벽을 세우는 모든 경우를 구하는 함수이다. 빈 칸의 위치가 담긴 리스트를 순회하며 백트래킹을 진행한다. 
- 깊이가 n-1인 경우(부분 집합의 n번째 원소를 결정하는 경우), 해당 노드를 방문하지 않았다면 방문 처리 후 벽을 세울 위치를 담는 리스트에 저장한다. 
- 이후 깊이를 1 늘려 함수를 재귀호출한다. 재귀호출 시 리스트를 순회할 때 마지막 방문한 노드의 다음 인덱스부터 진행한다.
- 재귀호출이 완료되면 방문처리한 것을 취소한다. 
- 깊이가 3이 되면 부분 집합의 원소가 3개가 된 상황이므로 bfs함수를 호출하여 안전 영역의 크기를 저장한다.
- 안전 영역 크기의 최댓값을 갱신하여 반환한다.


### 리뷰 받고 싶은 것
- 코드를 짜다 보니 많이 복잡해진 것 같습니다. 가독성이 떨어지거나 불필요한 부분이 있다면 꾸짖어 주세요...
- 그 외 모든 지적, 태클 환영합니다.