### PR TITLE
feat: 7주차(DP) 평범한 배낭

### DIFF
--- a/week07/yhs/BOJ_12865.py
+++ b/week07/yhs/BOJ_12865.py
@@ -1,0 +1,24 @@
+import sys
+
+n, k = map(int, input().split())
+
+items = []
+for _ in range(n):
+    w, v = map(int, sys.stdin.readline().split())
+    if w <= k:
+        items.append([w, v])      # 물건의 무게가 배낭에 넣을 수 있는 무게보다 큰 경우는 제외
+
+n = len(items)
+
+dp = [[0 for _ in range(n+1)] for _ in range(k+1)]      # 행: 무게 / 열: item
+
+for i in range(1, n+1):              # [무게, 가치]
+    w, v = items[i-1][0], items[i-1][1]
+
+    for j in range(1, w):           # i번째 물품의 무게(w_i)보다 작은 행의 테이블 : 현재 반복에서 갱신되지 않으므로 i-1번째 테이블의 정보를 그대로 가져옴
+        dp[j][i] = dp[j][i-1]
+
+    for j in range(w, k+1):         # w_i번째 행부터는 i-1번째 테이블의 값과 비교했을 때 더 큰 값으로 갱신
+        dp[j][i] = max(dp[j][i-1], v + dp[j-w][i-1])
+
+print(dp[-1][-1])


### PR DESCRIPTION
## 문제 조건
배낭 속 물건들의 무게의 합과 각 물건의 무게와 가치가 주어졌을 때, 배낭에 넣을 수 있는 물건들의 가치의 최댓값을 구하라.
- 물품의 수 n (1 ≤ n ≤ 100)
- 배낭 최대 무게 k (1 ≤ k ≤ 100,000)  
- 물품의 무게 w (1 ≤ w ≤ 100,000)  
    - 배낭 최대 무게보다 무거울 수 있음
- 물품의 가치 (0 ≤ v ≤ 1,000)

## 풀이
1. 배낭에 담을 수 있는 무게(k)보다 작거나 같은 물품들의 정보가 담긴 배열을 생성한다.
2. 각 물품의 정보를 조회하며 DP 테이블의 열을 갱신한다. i번째 물품의 무게(w)보다 작은 행의 원소는 갱신되지 않으므로 i-1번째 열의 정보를 그대로 가져온다. 나머지 행의 원소는 i-1번째 열의 같은 행의 원소와 비교하여 갱신한다. j(배낭의 무게)번째 행의 값은 `dp[j][i-1]`(i번째 물품을 넣지 않고 j만큼 채웠을 때 최대 가치)와 `dp[j][j-w] + v]`(i-1번째까지의 물품들을 이용해 j - w_i만큼 채우고 i번째 물품을 넣었을 때 최대 가치) 중 더 큰 값이 된다.
3. 모든 물품 정보를 조회하여 DP 테이블을 완성하고, 마지막 행 마지막 열 값을 출력한다.
### 접근 방법
고려할 조건이 2가지(물품의 무게, 가치)였기 때문에 DP 테이블을 2차원으로 만들었습니다. 테이블의 행은 배낭 속 모든 물품의 무게 합, 열은 현재까지 조회한 물품을 나타내며 각 원소에는 최대 가치가 담기게 됩니다. 즉, `dp[row][col]`은 col 번째까지의 물품을 이용해 배낭에 row 이하의 무게로 담았을 때 가치의 최대값입니다.  

### 특이사항

- #### 물품은 한 번씩만 사용할 수 있다.
DP를 갱신할 때 배낭 속 물품이 중복되지 않도록 코드를 작성했습니다. 현재 작성중인 열의 직전 열만 참고하면 각 물품을 최대 한 번만 사용한 결과를 얻을 수 있습니다. 
- #### 물품의 무게 조건
배낭 최대 무게와 물품의 무게 조건이 같아 처음에 단일 물품의 무게가 무조건 배낭 최대 무게보다 작을 것이라고 생각했지만, 문제에서 배낭 최대 무게와 각 물품의 무게와의 관계는 명시되어있지 않으며 w가 k보다 큰 경우가 있을 수 있습니다. 이 부분을 고려해서 w가 k보다 크면 물품 배열에 추가하지 않도록 코드를 수정한 결과, 에러가 발생하던 테스트케이스도 통과할 수 있었습니다.

## 리뷰 받고 싶은 점
- DP 테이블을 갱신할 때, 물품의 무게보다 작은 행(18\~19줄)을 갱신하는 부분과 물품의 무게 이상인 행(21~22줄)이 나누어져 있습니다. 두 동작을 하나의 반복문에서 이루어지도록 코드를 작성하고 싶었는데 실패했습니다. 혹시 방법을 알고 계신다면.. 
- 이외에도 코드의 효율성을 개선할 수 있는 방안
- 제가 작성한 코드지만 주석 처리와 description의 설명 내용이 미흡한 것 같습니다. 이해가 되지 않는 부분이 있다면 언제든 물어봐주333
