### PR TITLE
feat: week09/yhs/BOJ_2887.py 행성 터널

### DIFF
--- a/week09/yhs/BOJ_2887.py
+++ b/week09/yhs/BOJ_2887.py
@@ -1,0 +1,61 @@
+# 백준 2887번 행성 터널
+
+def find_set(x):  # 대표자 찾기
+    if parents[x] == x:
+        return x
+
+    parents[x] = find_set(parents[x])
+    return parents[x]
+
+
+def union(x, y):  # union
+    root_x = find_set(x)
+    root_y = find_set(y)
+
+    if root_x < root_y:
+        parents[root_y] = root_x
+    else:
+        parents[root_x] = root_y
+
+
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+x_sorted, y_sorted, z_sorted = [], [], []
+for i in range(n):
+    X, Y, Z = map(int, input().split())
+    # 각 축의 좌표와 노드번호 저장하기
+    x_sorted.append([X, i])
+    y_sorted.append([Y, i])
+    z_sorted.append([Z, i])
+
+# 오름차순으로 정렬
+x_sorted.sort()
+y_sorted.sort()
+z_sorted.sort()
+
+edges = []
+for i in range(n - 1):
+    # 각 축의 간선 저장(정렬을 통해 가장 가까운 거리의 간선만을 저장)
+    edges.append([x_sorted[i][1], x_sorted[i + 1][1], abs(x_sorted[i][0] - x_sorted[i + 1][0])])
+    edges.append([y_sorted[i][1], y_sorted[i + 1][1], abs(y_sorted[i][0] - y_sorted[i + 1][0])])
+    edges.append([z_sorted[i][1], z_sorted[i + 1][1], abs(z_sorted[i][0] - z_sorted[i + 1][0])])
+
+# 가중치 작은 순으로 모든 간선 정렬하기
+edges.sort(key=lambda x: x[2])
+
+parents = [x for x in range(n)]     # 각 노드의 부모 노드
+cnt = 0
+sum_cost = 0    #
+
+# Kruskal
+for v1, v2, cost in edges:
+    if find_set(v1) != find_set(v2):
+        cnt += 1
+        union(v1, v2)
+        sum_cost += cost
+        if cnt == n - 1:    # n-1개의 간선 완성 시 종료
+            break
+
+print(sum_cost)


### PR DESCRIPTION
## 백준 2887번 행성 터널 
N(1 ≤ N ≤ 100,000)개의 모든 행성을 N-1개의 간선으로 연결하는데 필요한 최소 비용을 구해라. 두 행성 A(xA, yA, zA)와 B(xB, yB, zB)를 연결했을 때의 비용은 `min(|xA-xB|, |yA-yB|, |zA-zB|)`이다.

## 풀이
모든 행성을 서로 이어지게 연결하는 문제이므로 최소 신장 트리를 이용한 풀이가 가장 먼저 떠올랐습니다. 
### 공간 복잡도 문제
최대 100,000개의 행성(노드)과 인접 행성을 연결했을 때 만들 수 있는 간선은 (100,000 * 99,999) / 2 = 4,999,950,000개입니다. 노드 개수에 비해 간선의 개수가 매우 많기 때문에 프림 알고리즘으로 풀이하려고 했으나, 우선순위 큐에  간선 정보를 전부 넣다보니 메모리 초과가 발생했습니다. 따라서 간선 정보를 저장할 때 가지치기가 필요하다고 판단했습니다.
각 축 좌표 정보를 정렬하여 `m번째 행성과 m+1번째 행성의 i축 좌표 차`를 가중치로 하는 간선만을 저장하여 개수를 nC2에서 3*(n-1)개로 줄였습니다. 이후 풀이의 편의성을 위해 노드 중심인 프림 알고리즘 대신 간선 중심의 크루스칼 알고리즘을 사용하는 것으로 바꿨습니다.

1. 각 축의 좌표를 오름차순으로 정리하고 노드번호와 함께 `x_sorted`, `y_sorted`, `z_sorted`에 저장합니다. 
2. 각각의 배열에서 2개의 연속한 항목의 정보로부터 인접한 2개의 노드 번호와 거리를 모아 `edges` 배열에 저장합니다. (정렬 후 연속한 항목의 거리이므로 가장 가까운 거리에 있는 노드의 거리를 저장하게 됨)
3. edges 배열을 가중치가 낮은 순으로 정렬하고 크루스칼 알고리즘을 통해 최소 비용을 구합니다.
